### PR TITLE
Add flatten/2, run NIFs on dirty schedulers, update pdfium

### DIFF
--- a/.dagger/lib/pdfium.ex
+++ b/.dagger/lib/pdfium.ex
@@ -338,10 +338,13 @@ defmodule Pdfium do
       def get_page_count(_document), do: :erlang.nif_error(:nif_not_loaded)
 
       def get_page_bitmap(_document, _page_number, _dpi), do: :erlang.nif_error(:nif_not_loaded)
+
+      def flatten(_document, _output_path), do: :erlang.nif_error(:nif_not_loaded)
     end
 
     {:ok, ref} = PDFium.NIF.load_document("./test.pdf")
     {:ok, pages} = PDFium.NIF.get_page_count(ref)
+    {:ok, :nothing_to_do} = PDFium.NIF.flatten(ref, "./flattened.pdf")
 
     IO.inspect(pages, label: "pages")
     """

--- a/LIBPDFIUM_TAG
+++ b/LIBPDFIUM_TAG
@@ -1,1 +1,1 @@
-chromium/7506
+chromium/7961

--- a/c_src/pdfium_nif.cpp
+++ b/c_src/pdfium_nif.cpp
@@ -1,6 +1,9 @@
 #include <fine.hpp>
 #include <fine/sync.hpp>
+#include <fpdf_flatten.h>
+#include <fpdf_save.h>
 #include <fpdfview.h>
+#include <cstdio>
 #include <mutex>
 #include <string>
 #include <variant>
@@ -10,6 +13,11 @@ static std::unique_ptr<fine::Mutex> pdfium_mutex;
 static fine::Atom document_closed("document_closed");
 static fine::Atom page_load_failed("page_load_failed");
 static fine::Atom bitmap_creation_failed("bitmap_creation_failed");
+static fine::Atom flattened("flattened");
+static fine::Atom nothing_to_do("nothing_to_do");
+static fine::Atom flatten_failed("flatten_failed");
+static fine::Atom output_open_failed("output_open_failed");
+static fine::Atom save_failed("save_failed");
 
 struct PDFDoc {
     FPDF_DOCUMENT document;
@@ -134,5 +142,74 @@ BitmapResult get_page_bitmap(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
 }
 
 FINE_NIF(get_page_bitmap, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
+namespace {
+
+struct FileWriter : FPDF_FILEWRITE {
+    std::FILE *file;
+};
+
+int write_block(FPDF_FILEWRITE *self, const void *data, unsigned long size) {
+    auto *writer = static_cast<FileWriter *>(self);
+    return std::fwrite(data, 1, size, writer->file) == size ? 1 : 0;
+}
+
+} // namespace
+
+using FlattenResult = std::variant<fine::Ok<fine::Atom>, fine::Error<fine::Atom>>;
+
+FlattenResult flatten(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
+                      std::string output_path) {
+    std::unique_lock lock(*pdfium_mutex);
+
+    if (!doc->document) {
+        return fine::Error(document_closed);
+    }
+
+    int page_count = FPDF_GetPageCount(doc->document);
+    bool changed = false;
+
+    for (int index = 0; index < page_count; index++) {
+        FPDF_PAGE page = FPDF_LoadPage(doc->document, index);
+        if (!page) {
+            return fine::Error(page_load_failed);
+        }
+
+        int result = FPDFPage_Flatten(page, FLAT_NORMALDISPLAY);
+        FPDF_ClosePage(page);
+
+        if (result == FLATTEN_FAIL) {
+            return fine::Error(flatten_failed);
+        }
+
+        if (result == FLATTEN_SUCCESS) {
+            changed = true;
+        }
+    }
+
+    if (!changed) {
+        return fine::Ok(nothing_to_do);
+    }
+
+    FileWriter writer{};
+    writer.version = 1;
+    writer.WriteBlock = write_block;
+    writer.file = std::fopen(output_path.c_str(), "wb");
+
+    if (!writer.file) {
+        return fine::Error(output_open_failed);
+    }
+
+    FPDF_BOOL saved = FPDF_SaveAsCopy(doc->document, &writer, 0);
+    std::fclose(writer.file);
+
+    if (!saved) {
+        return fine::Error(save_failed);
+    }
+
+    return fine::Ok(flattened);
+}
+
+FINE_NIF(flatten, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 FINE_INIT("Elixir.PDFium.NIF");

--- a/c_src/pdfium_nif.cpp
+++ b/c_src/pdfium_nif.cpp
@@ -54,7 +54,7 @@ DocResult load_document(ErlNifEnv *env, std::string filename) {
     return fine::Ok(fine::make_resource<PDFDoc>(document));
 }
 
-FINE_NIF(load_document, 0);
+FINE_NIF(load_document, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 fine::Ok<> close_document(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc) {
     std::unique_lock lock(*pdfium_mutex);
@@ -65,7 +65,7 @@ fine::Ok<> close_document(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc) {
     return fine::Ok<>();
 }
 
-FINE_NIF(close_document, 0);
+FINE_NIF(close_document, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 using CountResult = std::variant<fine::Ok<int64_t>, fine::Error<fine::Atom>>;
 
@@ -77,7 +77,7 @@ CountResult get_page_count(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc) {
     return fine::Ok(static_cast<int64_t>(FPDF_GetPageCount(doc->document)));
 }
 
-FINE_NIF(get_page_count, 0);
+FINE_NIF(get_page_count, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 using BitmapResult = std::variant<fine::Ok<std::string, int64_t, int64_t>, fine::Error<fine::Atom>>;
 
@@ -133,6 +133,6 @@ BitmapResult get_page_bitmap(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
                     static_cast<int64_t>(height));
 }
 
-FINE_NIF(get_page_bitmap, 0);
+FINE_NIF(get_page_bitmap, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 FINE_INIT("Elixir.PDFium.NIF");

--- a/custom/builds.json
+++ b/custom/builds.json
@@ -5,8 +5,8 @@
       "arch": "arm64",
       "otp": "29.0.3",
       "fine_tag": "v0.1.6",
-      "pdfium_download_link": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7506/pdfium-mac-arm64.tgz",
-      "pdfium_sha256sum": "afba59f29e654335d64e06c5c25fd652c515f4bce2b00a4cba008e6d31ef2c98",
+      "pdfium_download_link": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7961/pdfium-mac-arm64.tgz",
+      "pdfium_sha256sum": "1193a771e0bd934530afa3df73a0d44551d8f4078442e290054e6dd38ded960f",
       "otp_download_link": "https://github.com/erlef/otp_builds/releases/download/OTP-29.0.3/OTP-29.0.3-macos-arm64.tar.gz",
       "otp_sha256sum": "bfb187843b00fdff9a9eb79f15f17ffcd48d89150212f77206279fcd51136706",
       "nif_version": "2.18"
@@ -16,8 +16,8 @@
       "arch": "x86_64",
       "otp": "29.0.3",
       "fine_tag": "v0.1.6",
-      "pdfium_download_link": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7506/pdfium-mac-x64.tgz",
-      "pdfium_sha256sum": "2e76873aebc2f6b81b6487070574c2aa8270002fb36a4c1e4e194cd88a7e973d",
+      "pdfium_download_link": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7961/pdfium-mac-x64.tgz",
+      "pdfium_sha256sum": "17f069d7012ab83898ad5eddebd139b240f05d7411c220775d507a0e3e285536",
       "otp_download_link": "https://github.com/erlef/otp_builds/releases/download/OTP-29.0.3/OTP-29.0.3-macos-amd64.tar.gz",
       "otp_sha256sum": "9fb73031da37363200df4459ef57e16bb4e00134ec94bfb92b7a1b4db640dcca",
       "nif_version": "2.18"

--- a/lib/pdfium.ex
+++ b/lib/pdfium.ex
@@ -6,4 +6,6 @@ defmodule PDFium do
   defdelegate get_page_count(document), to: PDFium.NIF
 
   defdelegate get_page_bitmap(document, page_number, dpi), to: PDFium.NIF
+
+  defdelegate flatten(document, output_path), to: PDFium.NIF
 end

--- a/lib/pdfium/nif.ex
+++ b/lib/pdfium/nif.ex
@@ -13,4 +13,6 @@ defmodule PDFium.NIF do
   def get_page_count(_document), do: :erlang.nif_error(:nif_not_loaded)
 
   def get_page_bitmap(_document, _page_number, _dpi), do: :erlang.nif_error(:nif_not_loaded)
+
+  def flatten(_document, _output_path), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/test/fixtures/annotated.pdf
+++ b/test/fixtures/annotated.pdf
@@ -1,0 +1,41 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << >> /Annots [5 0 R] >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+0 0 1 rg 20 20 60 60 re f
+           
+endstream
+endobj
+5 0 obj
+<< /Type /Annot /Subtype /Square /Rect [100 100 180 180] /F 4 /AP << /N 6 0 R >> >>
+endobj
+6 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 80 80] /Length 42 >>
+stream
+1 0 0 rg 5 5 70 70 re f
+                
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000235 00000 n 
+0000000322 00000 n 
+0000000421 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+559
+%%EOF

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -1,8 +1,66 @@
 defmodule PDFiumTest do
   use ExUnit.Case
-  doctest PDFium
 
-  test "greets the world" do
-    assert 1 == 1
+  @annotated Path.expand("fixtures/annotated.pdf", __DIR__)
+  @plain Path.expand("../custom/test.pdf", __DIR__)
+
+  setup do
+    output = Path.join(System.tmp_dir!(), "pdfium-test-#{System.unique_integer([:positive])}.pdf")
+    on_exit(fn -> File.rm(output) end)
+
+    {:ok, output: output}
+  end
+
+  describe "flatten/2" do
+    test "renders annotations into the page and writes the result", %{output: output} do
+      {:ok, document} = PDFium.load_document(@annotated)
+
+      assert {:ok, :flattened} = PDFium.flatten(document, output)
+      assert File.exists?(output)
+
+      PDFium.close_document(document)
+
+      {:ok, flattened} = PDFium.load_document(output)
+      assert {:ok, 1} = PDFium.get_page_count(flattened)
+      PDFium.close_document(flattened)
+    end
+
+    test "leaves the output alone when there is nothing to flatten", %{output: output} do
+      {:ok, document} = PDFium.load_document(@plain)
+
+      assert {:ok, :nothing_to_do} = PDFium.flatten(document, output)
+      refute File.exists?(output)
+
+      PDFium.close_document(document)
+    end
+
+    test "is idempotent", %{output: output} do
+      {:ok, document} = PDFium.load_document(@annotated)
+      assert {:ok, :flattened} = PDFium.flatten(document, output)
+      PDFium.close_document(document)
+
+      {:ok, flattened} = PDFium.load_document(output)
+      second = output <> ".2"
+      on_exit(fn -> File.rm(second) end)
+
+      assert {:ok, :nothing_to_do} = PDFium.flatten(flattened, second)
+      PDFium.close_document(flattened)
+    end
+
+    test "reports a closed document", %{output: output} do
+      {:ok, document} = PDFium.load_document(@annotated)
+      PDFium.close_document(document)
+
+      assert {:error, :document_closed} = PDFium.flatten(document, output)
+    end
+
+    test "reports an unwritable output path" do
+      {:ok, document} = PDFium.load_document(@annotated)
+
+      assert {:error, :output_open_failed} =
+               PDFium.flatten(document, "/nonexistent-directory/out.pdf")
+
+      PDFium.close_document(document)
+    end
   end
 end


### PR DESCRIPTION
Adds `PDFium.flatten/2`, which renders annotation appearances into the page content stream and drops the annotation objects. Callers doing this today shell out to Ghostscript, which re-encodes the whole document and shifts rendering slightly; `FPDFPage_Flatten` leaves the page pixel-identical. When no page has anything to flatten it returns `{:ok, :nothing_to_do}` and writes nothing, so the caller can keep using its input file.

Also moves every NIF to `ERL_NIF_DIRTY_JOB_CPU_BOUND`. They all take the same global mutex, so any call can block for as long as the longest call in flight, and `get_page_bitmap` was already well past what a normal scheduler tolerates.

Finally updates pdfium from `chromium/7506` to `chromium/7961`, with checksums recomputed from the published archives.

One thing worth knowing before a release: the pdfium bump moves the renderer behind `get_page_bitmap`, and nothing here covers rendering fidelity, so it is worth checking against a real consumer first.

Unrelated things noticed while working on this, not touched: `custom/build-all.sh` passes OTP `28.1`, which has no entry in `custom/builds.json`, and the build artefact `custom/pdfium-nif-*.tar.gz` has no gitignore rule.