### PR TITLE
Measure a string that is only whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 pdfium-*.tar
 
+# Ignore the NIF archives the macOS build writes beside the script.
+custom/pdfium-nif-*.tar.gz
+
 # Temporary files, for example, from tests.
 /tmp/
 /priv/

--- a/c_src/pdfium_nif.cpp
+++ b/c_src/pdfium_nif.cpp
@@ -355,7 +355,13 @@ MeasureResult measure_text(ErlNifEnv *env, fine::ResourcePtr<PDFFont> font, doub
         FPDF_PAGEOBJECT object =
             FPDFPageObj_CreateTextObj(font->document, font->font, static_cast<float>(size));
 
-        auto utf16 = to_utf16(text);
+        // A character's box is derived from its glyph outline, so a blank glyph
+        // ending a run measures as nothing and " " comes back as zero. Appending
+        // a sentinel and taking the distance the pen travelled measures
+        // advances rather than ink, which is what a width is. The sentinel's own
+        // advance never enters the result, so it does not matter whether the
+        // font even has that character.
+        auto utf16 = to_utf16(text + "A");
         FPDFText_SetText(object, utf16.data());
         FPDFPage_InsertObject(page, object);
         FPDFPage_GenerateContent(page);
@@ -364,11 +370,11 @@ MeasureResult measure_text(ErlNifEnv *env, fine::ResourcePtr<PDFFont> font, doub
         double width = 0.0;
 
         int count = FPDFText_CountChars(text_page);
-        for (int index = 0; index < count; index++) {
-            FS_RECTF rect;
-            if (FPDFText_GetLooseCharBox(text_page, index, &rect)) {
-                width += rect.right - rect.left;
-            }
+        double start_x, start_y, end_x, end_y;
+
+        if (count > 1 && FPDFText_GetCharOrigin(text_page, 0, &start_x, &start_y) &&
+            FPDFText_GetCharOrigin(text_page, count - 1, &end_x, &end_y)) {
+            width = end_x - start_x;
         }
 
         FPDFText_ClosePage(text_page);

--- a/custom/build-for-mac.sh
+++ b/custom/build-for-mac.sh
@@ -97,7 +97,9 @@ fi
 output_name="pdfium-nif-${nif_version}-${otp_arch}-apple-darwin-$(cat ../VERSION).tar.gz"
 
 # 6. Create archive
-tar --create \
+# -s is BSD tar's substitution flag; GNU tar reads it as --same-order and
+# refuses. The system tar is the BSD one, whatever else is on PATH.
+/usr/bin/tar --create \
     --verbose \
     --file="$output_name" \
     -s '|.*/||' \

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -111,6 +111,16 @@ defmodule PDFiumTest do
       assert_widths(widths, [9.0])
     end
 
+    test "measures a string that is only whitespace", %{font: font} do
+      # Nothing inked anchors this measurement, so summing glyph extents answers
+      # zero for a single space and loses one space from every longer run.
+      # Callers that measure the gaps between words as strings in their own right
+      # would be told there are no gaps.
+      assert {:ok, widths} = PDFium.measure_text(font, 12.0, [" ", "  ", "   "])
+
+      assert_widths(widths, [3.0, 6.0, 9.0])
+    end
+
     test "measures characters outside latin-1", %{font: font} do
       # ę is 600 units where .notdef is 500. A simple, single byte encoded font
       # would fall back to .notdef here and quietly answer 6.0.


### PR DESCRIPTION
Measuring a string that is only whitespace answered short: a single space came back as `0.0`, and every longer run of spaces was one space light. Widths were summed from each character's box, and a box is derived from the glyph outline, so a blank glyph at the end of a run contributes nothing.

`measure_text` now appends a sentinel character and takes the distance between the first and the last pen position, so it reads advances rather than ink. The sentinel's own advance never enters the result, so it does not matter whether the font has that character at all.

This matters for callers that lay a line out one word at a time and measure the gaps between words as strings in their own right — they were being told there are no gaps. Checked against a font with known advances: `" "`, `"  "` and `"   "` now measure 250, 500 and 750 units, and every case that already worked is unchanged.

Two smaller things came up while building this locally. The macOS archive step passes BSD tar's `-s` flag, which GNU tar reads as `--same-order` and refuses alongside `-c`, so the build stopped before copying anything into `priv` wherever GNU tar comes first on `PATH`. And the NIF archives that build writes are now ignored instead of piling up untracked.