### PR TITLE
Add PDFium.draw_text/5

### DIFF
--- a/.dagger/lib/pdfium.ex
+++ b/.dagger/lib/pdfium.ex
@@ -389,6 +389,9 @@ defmodule Pdfium do
       def close_font(_font), do: :erlang.nif_error(:nif_not_loaded)
 
       def measure_text(_font, _size, _texts), do: :erlang.nif_error(:nif_not_loaded)
+
+      def draw_text(_font, _size, _width, _height, _texts, _xs, _ys, _output_path),
+        do: :erlang.nif_error(:nif_not_loaded)
     end
 
     {:ok, ref} = PDFium.NIF.load_document("./test.pdf")

--- a/c_src/pdfium_nif.cpp
+++ b/c_src/pdfium_nif.cpp
@@ -22,6 +22,11 @@ static fine::Atom output_open_failed("output_open_failed");
 static fine::Atom save_failed("save_failed");
 static fine::Atom font_load_failed("font_load_failed");
 static fine::Atom font_closed("font_closed");
+static fine::Atom placement_mismatch("placement_mismatch");
+static fine::Atom page_creation_failed("page_creation_failed");
+static fine::Atom text_object_failed("text_object_failed");
+static fine::Atom generate_content_failed("generate_content_failed");
+static fine::Atom drawn("drawn");
 
 struct PDFDoc {
     FPDF_DOCUMENT document;
@@ -391,5 +396,85 @@ MeasureResult measure_text(ErlNifEnv *env, fine::ResourcePtr<PDFFont> font, doub
 }
 
 FINE_NIF(measure_text, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
+using DrawResult = std::variant<fine::Ok<fine::Atom>, fine::Error<fine::Atom>>;
+
+// Draws every string on one page of its own document and writes it out, for
+// compositing onto the page it belongs over.
+//
+// The page is built inside the document the font was loaded into, because a page
+// object belongs to the document that made it and the font cannot be borrowed
+// across one. It is removed again afterwards, so the document a caller holds is
+// no larger for having drawn.
+//
+// Positions are the pen, so y is the baseline rather than the bottom of the
+// glyphs, which is what a text placement means everywhere else.
+DrawResult draw_text(ErlNifEnv *env, fine::ResourcePtr<PDFFont> font, double size, double width,
+                     double height, std::vector<std::string> texts, std::vector<double> xs,
+                     std::vector<double> ys, std::string output_path) {
+    std::unique_lock lock(*pdfium_mutex);
+
+    if (!font->font) {
+        return fine::Error(font_closed);
+    }
+
+    if (texts.size() != xs.size() || texts.size() != ys.size()) {
+        return fine::Error(placement_mismatch);
+    }
+
+    FPDF_PAGE page = FPDFPage_New(font->document, 0, width, height);
+
+    if (!page) {
+        return fine::Error(page_creation_failed);
+    }
+
+    for (size_t index = 0; index < texts.size(); index++) {
+        FPDF_PAGEOBJECT object =
+            FPDFPageObj_CreateTextObj(font->document, font->font, static_cast<float>(size));
+
+        if (!object) {
+            FPDF_ClosePage(page);
+            FPDFPage_Delete(font->document, 0);
+            return fine::Error(text_object_failed);
+        }
+
+        auto utf16 = to_utf16(texts[index]);
+        FPDFText_SetText(object, utf16.data());
+        FPDFPageObj_SetFillColor(object, 0, 0, 0, 255);
+        FPDFPageObj_Transform(object, 1, 0, 0, 1, xs[index], ys[index]);
+        FPDFPage_InsertObject(page, object);
+    }
+
+    FPDF_BOOL generated = FPDFPage_GenerateContent(page);
+    FPDF_ClosePage(page);
+
+    if (!generated) {
+        FPDFPage_Delete(font->document, 0);
+        return fine::Error(generate_content_failed);
+    }
+
+    FileWriter writer{};
+    writer.version = 1;
+    writer.WriteBlock = write_block;
+    writer.file = std::fopen(output_path.c_str(), "wb");
+
+    if (!writer.file) {
+        FPDFPage_Delete(font->document, 0);
+        return fine::Error(output_open_failed);
+    }
+
+    FPDF_BOOL saved = FPDF_SaveAsCopy(font->document, &writer, 0);
+    std::fclose(writer.file);
+
+    FPDFPage_Delete(font->document, 0);
+
+    if (!saved) {
+        return fine::Error(save_failed);
+    }
+
+    return fine::Ok(drawn);
+}
+
+FINE_NIF(draw_text, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 FINE_INIT("Elixir.PDFium.NIF");

--- a/lib/pdfium.ex
+++ b/lib/pdfium.ex
@@ -14,4 +14,28 @@ defmodule PDFium do
   defdelegate close_font(font), to: PDFium.NIF
 
   defdelegate measure_text(font, size, texts), to: PDFium.NIF
+
+  @doc """
+  Draws strings onto a page of the given size and writes it out on its own.
+
+  Each placement is `{text, x, y}`, where the point is the pen: `y` is the
+  baseline, and `x` the left edge of the first glyph's advance.
+  """
+  @spec draw_text(
+          reference(),
+          number(),
+          {number(), number()},
+          [{binary(), number(), number()}],
+          Path.t()
+        ) :: {:ok, :drawn} | {:error, atom()}
+  # Coordinates are floats at the boundary. Whole numbers are the natural way to
+  # say a page is 612 by 792, and a list of small integers is a charlist, which
+  # is not what the other side is expecting to decode.
+  def draw_text(font, size, {width, height}, placements, output_path) do
+    texts = Enum.map(placements, &elem(&1, 0))
+    xs = Enum.map(placements, &(elem(&1, 1) / 1))
+    ys = Enum.map(placements, &(elem(&1, 2) / 1))
+
+    PDFium.NIF.draw_text(font, size / 1, width / 1, height / 1, texts, xs, ys, output_path)
+  end
 end

--- a/lib/pdfium/nif.ex
+++ b/lib/pdfium/nif.ex
@@ -21,4 +21,7 @@ defmodule PDFium.NIF do
   def close_font(_font), do: :erlang.nif_error(:nif_not_loaded)
 
   def measure_text(_font, _size, _texts), do: :erlang.nif_error(:nif_not_loaded)
+
+  def draw_text(_font, _size, _width, _height, _texts, _xs, _ys, _output_path),
+    do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -161,4 +161,109 @@ defmodule PDFiumTest do
       assert {:error, :font_load_failed} = PDFium.load_font("not a font")
     end
   end
+
+  describe "draw_text/5" do
+    setup do
+      {:ok, font} = PDFium.load_font(File.read!(Path.expand("fixtures/measuring.ttf", __DIR__)))
+
+      {:ok, font: font}
+    end
+
+    # The bitmap runs top down and a page runs bottom up, so a row has to be
+    # turned back around before it can be compared with the baseline asked for.
+    defp ink_box(path) do
+      {:ok, document} = PDFium.load_document(path)
+
+      try do
+        {:ok, bitmap, width, height} = PDFium.get_page_bitmap(document, 0, 72)
+
+        {box, _index} =
+          for <<r::8, g::8, b::8, _a::8 <- bitmap>>, reduce: {nil, 0} do
+            {box, index} ->
+              if div(r + g + b, 3) < 200 do
+                x = rem(index, width)
+                y = height - div(index, width) - 1
+
+                case box do
+                  nil -> {{x, y, x, y}, index + 1}
+                  {x0, y0, x1, y1} -> {{min(x0, x), min(y0, y), max(x1, x), max(y1, y)}, index + 1}
+                end
+              else
+                {box, index + 1}
+              end
+          end
+
+        box
+      after
+        PDFium.close_document(document)
+      end
+    end
+
+    test "puts the pen where it was told to", %{font: font, output: output} do
+      assert {:ok, :drawn} = PDFium.draw_text(font, 48.0, {300, 300}, [{"A", 100, 150}], output)
+
+      assert {x0, y0, _x1, _y1} = ink_box(output)
+
+      # The glyph fills its cell and has no side bearings, so its corner is the pen.
+      assert_in_delta x0, 100, 2
+      assert_in_delta y0, 150, 2
+    end
+
+    test "keeps the placements apart", %{font: font, output: output} do
+      placements = [{"A", 40, 60}, {"A", 40, 200}]
+
+      assert {:ok, :drawn} = PDFium.draw_text(font, 24.0, {300, 300}, placements, output)
+
+      assert {_x0, y0, _x1, y1} = ink_box(output)
+
+      assert y1 - y0 > 140, "two baselines 140 apart should span at least that far"
+    end
+
+    test "writes a page of the size it was given", %{font: font, output: output} do
+      assert {:ok, :drawn} = PDFium.draw_text(font, 12.0, {200, 400}, [{"A", 10, 10}], output)
+
+      {:ok, document} = PDFium.load_document(output)
+      {:ok, _bitmap, width, height} = PDFium.get_page_bitmap(document, 0, 72)
+      PDFium.close_document(document)
+
+      assert {width, height} == {200, 400}
+    end
+
+    test "writes one page however many times it is called", %{font: font, output: output} do
+      # The page is built inside the font's own document, so failing to take it
+      # back out would leave the next overlay carrying every page drawn before it.
+      for _ <- 1..5 do
+        assert {:ok, :drawn} = PDFium.draw_text(font, 12.0, {100, 100}, [{"A", 10, 10}], output)
+      end
+
+      {:ok, document} = PDFium.load_document(output)
+      assert {:ok, 1} = PDFium.get_page_count(document)
+      PDFium.close_document(document)
+    end
+
+    test "draws nothing when given nothing", %{font: font, output: output} do
+      assert {:ok, :drawn} = PDFium.draw_text(font, 12.0, {100, 100}, [], output)
+
+      assert ink_box(output) == nil
+    end
+
+    test "still measures after drawing", %{font: font, output: output} do
+      assert {:ok, :drawn} = PDFium.draw_text(font, 12.0, {100, 100}, [{"A", 10, 10}], output)
+
+      assert {:ok, [width]} = PDFium.measure_text(font, 12.0, ["A"])
+      assert_in_delta width, 6.0, 0.0001
+    end
+
+    test "reports a closed font", %{font: font, output: output} do
+      assert :ok = PDFium.close_font(font)
+
+      assert {:error, :font_closed} =
+               PDFium.draw_text(font, 12.0, {100, 100}, [{"A", 10, 10}], output)
+    end
+
+    test "reports placements that do not line up", %{font: font, output: output} do
+      assert {:error, :placement_mismatch} =
+               PDFium.NIF.draw_text(font, 12.0, 100.0, 100.0, ["A", "B"], [10.0], [10.0], output)
+    end
+  end
 end


### PR DESCRIPTION
Draws strings onto a page of its own and writes it out, for compositing over the page they belong on. Positions are the pen, so `y` is the baseline rather than the bottom of the glyphs — that is what a text placement means everywhere it comes from.

The page is built inside the document the font was loaded into, because a page object belongs to the document that created it and a font cannot be borrowed across one. It is taken back out afterwards, so a caller holding a font can draw as often as it likes without that document growing, and without the next overlay carrying the last one's page along with it. There is a test for exactly that, since it would otherwise show up as a second blank page in someone else's document.

The point of this is to replace a Ghostscript invocation per line of text with one call for the whole overlay, and with it about 580 lines of PostScript that exists only because a PostScript font addresses 256 glyphs at a time.