### PR TITLE
Open a document for the length of a job and close it again

### DIFF
--- a/lib/pdfium.ex
+++ b/lib/pdfium.ex
@@ -27,6 +27,26 @@ defmodule PDFium do
 
   defdelegate close_document(document), to: PDFium.NIF
 
+  @doc """
+  Opens the document at `path`, runs `function` with it, and closes it again.
+
+  Closing is what hands back the memory a document holds at a known moment
+  rather than whenever the reference is collected, and it happens even if the
+  work raises: a caller that answers its own errors would otherwise hold onto
+  the document for as long as the process lives.
+  """
+  @spec with_document(Path.t(), (reference() -> result)) :: result | {:error, load_error()}
+        when result: term()
+  def with_document(path, function) do
+    with {:ok, document} <- load_document(path) do
+      try do
+        function.(document)
+      after
+        close_document(document)
+      end
+    end
+  end
+
   defdelegate get_page_count(document), to: PDFium.NIF
 
   @doc """

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -58,6 +58,41 @@ defmodule PDFiumTest do
     end
   end
 
+  describe "with_document/2" do
+    test "runs the function with the document it opened" do
+      path = tmp_path() |> Document.write!([[box: {0, 0, 100, 100}], []])
+
+      assert {:ok, 2} = PDFium.with_document(path, &PDFium.get_page_count/1)
+    end
+
+    test "closes the document afterwards" do
+      document = PDFium.with_document(@plain, & &1)
+
+      assert {:error, :document_closed} = PDFium.get_page_count(document)
+    end
+
+    test "closes the document even when the work raises" do
+      test = self()
+
+      assert_raise RuntimeError, "the work failed", fn ->
+        PDFium.with_document(@plain, fn document ->
+          send(test, {:document, document})
+          raise "the work failed"
+        end)
+      end
+
+      assert_received {:document, document}
+      assert {:error, :document_closed} = PDFium.get_page_count(document)
+    end
+
+    test "answers the reason it could not open the document, and does not run" do
+      assert {:error, :file} =
+               PDFium.with_document("/nonexistent-directory/absent.pdf", fn _document ->
+                 flunk("ran against a document that was never opened")
+               end)
+    end
+  end
+
   describe "get_page_bitmap/3" do
     defp ink(path) do
       document = open!(path)


### PR DESCRIPTION
file_service has carried its own `with_document/2` since the pdfcpu migration, and every caller of `load_document/1` there writes the same `try/after`. The library already has that shape for a document it creates — `with_new_document/1` — but not for one it reads from a file, so this adds the missing half.

Based on `stable` rather than `main`: `main` is three commits behind (the nix shell, the 0.1.35 release, and its checksums all landed on `stable`), and is a strict ancestor, so it can be fast-forwarded whenever you want them to line up again.