### PR TITLE
Name the documents a job works on rather than take them open

### DIFF
--- a/lib/pdfium.ex
+++ b/lib/pdfium.ex
@@ -27,6 +27,26 @@ defmodule PDFium do
 
   defdelegate close_document(document), to: PDFium.NIF
 
+  @doc """
+  Opens the document at `path`, runs `function` with it, and closes it again.
+
+  Closing is what hands back the memory a document holds at a known moment
+  rather than whenever the reference is collected, and it happens even if the
+  work raises: a caller that answers its own errors would otherwise hold onto
+  the document for as long as the process lives.
+  """
+  @spec with_document(Path.t(), (reference() -> result)) :: result | {:error, load_error()}
+        when result: term()
+  def with_document(path, function) do
+    with {:ok, document} <- load_document(path) do
+      try do
+        function.(document)
+      after
+        close_document(document)
+      end
+    end
+  end
+
   defdelegate get_page_count(document), to: PDFium.NIF
 
   @doc """

--- a/lib/pdfium/toolbox.ex
+++ b/lib/pdfium/toolbox.ex
@@ -6,6 +6,10 @@ defmodule PDFium.Toolbox do
   here because more than one caller wanted it. Where a job has to decide
   something the library cannot know — where an overlay belongs on a page, say —
   it is decided here rather than in the binding.
+
+  A job names its documents by path rather than taking them open, and opens and
+  closes them itself. Reach for `PDFium` when you want to hold a document open
+  across several pieces of work.
   """
 
   @doc """
@@ -19,16 +23,21 @@ defmodule PDFium.Toolbox do
   goes over land exactly where it was drawn. `PDFium.stamp/3` takes the matrix
   itself for anywhere else.
   """
-  @spec stamp(reference(), [{reference(), non_neg_integer()}], Path.t()) ::
+  @spec stamp(Path.t(), [{Path.t(), non_neg_integer()}], Path.t()) ::
           {:ok, :stamped} | {:error, atom()}
-  def stamp(document, placements, output_path) do
-    overlays = placements |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+  def stamp(path, placements, output_path) do
+    overlay_paths = placements |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
 
-    with {:ok, [pages | overlay_pages]} <- PDFium.get_page_sizes([document | overlays]),
-         sizes = overlays |> Enum.zip(overlay_pages) |> Map.new(),
-         {:ok, placed} <- fit_each(placements, pages, sizes) do
-      PDFium.stamp(document, placed, output_path)
-    end
+    with_documents([path | overlay_paths], fn [document | overlays] ->
+      by_path = Map.new(Enum.zip(overlay_paths, overlays))
+      named = Enum.map(placements, fn {path, page} -> {Map.fetch!(by_path, path), page} end)
+
+      with {:ok, [pages | overlay_pages]} <- PDFium.get_page_sizes([document | overlays]),
+           sizes = overlays |> Enum.zip(overlay_pages) |> Map.new(),
+           {:ok, placed} <- fit_each(named, pages, sizes) do
+        PDFium.stamp(document, placed, output_path)
+      end
+    end)
   end
 
   @spec fit_each([{reference(), non_neg_integer()}], [PDFium.page_size()], map()) ::
@@ -74,19 +83,21 @@ defmodule PDFium.Toolbox do
   Answers `{:ok, :nothing_to_do}` without writing anything when no page had an
   annotation to draw.
   """
-  @spec flatten(reference(), Path.t()) ::
+  @spec flatten(Path.t(), Path.t()) ::
           {:ok, :flattened | :nothing_to_do} | {:error, atom()}
-  @spec flatten(reference(), Path.t(), :display | :print) ::
+  @spec flatten(Path.t(), Path.t(), :display | :print) ::
           {:ok, :flattened | :nothing_to_do} | {:error, atom()}
-  def flatten(document, output_path, usage \\ :display) do
-    with {:ok, page_count} <- PDFium.get_page_count(document),
-         {:ok, drawn?} <- flatten_each(document, page_count, usage) do
-      if drawn? do
-        with {:ok, :saved} <- PDFium.save(document, output_path), do: {:ok, :flattened}
-      else
-        {:ok, :nothing_to_do}
+  def flatten(path, output_path, usage \\ :display) do
+    PDFium.with_document(path, fn document ->
+      with {:ok, page_count} <- PDFium.get_page_count(document),
+           {:ok, drawn?} <- flatten_each(document, page_count, usage) do
+        if drawn? do
+          with {:ok, :saved} <- PDFium.save(document, output_path), do: {:ok, :flattened}
+        else
+          {:ok, :nothing_to_do}
+        end
       end
-    end
+    end)
   end
 
   @spec flatten_each(reference(), non_neg_integer(), :display | :print) ::
@@ -102,17 +113,21 @@ defmodule PDFium.Toolbox do
   end
 
   @doc """
-  Writes the given documents as one, in the order given.
+  Writes the named documents as one, in the order named.
+
+  A document named twice is written twice.
   """
-  @spec merge([reference()], Path.t()) :: {:ok, :merged} | {:error, atom()}
+  @spec merge([Path.t()], Path.t()) :: {:ok, :merged} | {:error, atom()}
   def merge([], _output_path), do: {:error, :no_documents}
 
-  def merge(documents, output_path) do
-    PDFium.with_new_document(fn output ->
-      with {:ok, _at} <- import_each(output, documents),
-           {:ok, :saved} <- PDFium.save(output, output_path) do
-        {:ok, :merged}
-      end
+  def merge(paths, output_path) do
+    with_documents(paths, fn documents ->
+      PDFium.with_new_document(fn output ->
+        with {:ok, _at} <- import_each(output, documents),
+             {:ok, :saved} <- PDFium.save(output, output_path) do
+          {:ok, :merged}
+        end
+      end)
     end)
   end
 
@@ -134,14 +149,35 @@ defmodule PDFium.Toolbox do
   Pages are numbered from zero. Naming one twice writes it twice; naming none
   is refused rather than taken to mean all of them.
   """
-  @spec extract_pages(reference(), [non_neg_integer()], Path.t()) ::
+  @spec extract_pages(Path.t(), [non_neg_integer()], Path.t()) ::
           {:ok, :extracted} | {:error, atom()}
-  def extract_pages(document, page_indices, output_path) do
-    PDFium.with_new_document(fn output ->
-      with {:ok, :imported} <- PDFium.import_pages(output, document, page_indices, 0),
-           {:ok, :saved} <- PDFium.save(output, output_path) do
-        {:ok, :extracted}
-      end
+  def extract_pages(path, page_indices, output_path) do
+    PDFium.with_document(path, fn document ->
+      PDFium.with_new_document(fn output ->
+        with {:ok, :imported} <- PDFium.import_pages(output, document, page_indices, 0),
+             {:ok, :saved} <- PDFium.save(output, output_path) do
+          {:ok, :extracted}
+        end
+      end)
     end)
+  end
+
+  @spec with_documents([Path.t()], ([reference()] -> result)) ::
+          result | {:error, PDFium.load_error()}
+        when result: term()
+  defp with_documents(paths, function) do
+    opened = Enum.map(paths, &PDFium.load_document/1)
+
+    try do
+      case Enum.find(opened, &match?({:error, _reason}, &1)) do
+        nil -> function.(Enum.map(opened, fn {:ok, document} -> document end))
+        {:error, reason} -> {:error, reason}
+      end
+    after
+      Enum.each(opened, fn
+        {:ok, document} -> PDFium.close_document(document)
+        {:error, _reason} -> :ok
+      end)
+    end
   end
 end

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -58,6 +58,41 @@ defmodule PDFiumTest do
     end
   end
 
+  describe "with_document/2" do
+    test "runs the function with the document it opened" do
+      path = tmp_path() |> Document.write!([[box: {0, 0, 100, 100}], []])
+
+      assert {:ok, 2} = PDFium.with_document(path, &PDFium.get_page_count/1)
+    end
+
+    test "closes the document afterwards" do
+      document = PDFium.with_document(@plain, & &1)
+
+      assert {:error, :document_closed} = PDFium.get_page_count(document)
+    end
+
+    test "closes the document even when the work raises" do
+      test = self()
+
+      assert_raise RuntimeError, "the work failed", fn ->
+        PDFium.with_document(@plain, fn document ->
+          send(test, {:document, document})
+          raise "the work failed"
+        end)
+      end
+
+      assert_received {:document, document}
+      assert {:error, :document_closed} = PDFium.get_page_count(document)
+    end
+
+    test "answers the reason it could not open the document, and does not run" do
+      assert {:error, :file} =
+               PDFium.with_document("/nonexistent-directory/absent.pdf", fn _document ->
+                 flunk("ran against a document that was never opened")
+               end)
+    end
+  end
+
   describe "get_page_bitmap/3" do
     defp ink(path) do
       document = open!(path)

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -108,8 +108,7 @@ defmodule PDFiumTest do
       # covers ink rather than adding any. Flattening draws the same appearance
       # into the page content, so the two have to come out identical.
       flattened = tmp_path()
-      document = open!(@annotated)
-      assert {:ok, :flattened} = Toolbox.flatten(document, flattened)
+      assert {:ok, :flattened} = Toolbox.flatten(@annotated, flattened)
 
       assert ink(@annotated) == ink(flattened)
     end
@@ -325,7 +324,7 @@ defmodule PDFiumTest do
     setup do
       pages = Enum.map([200, 300, 400, 500], &[box: {0, 0, &1, &1}])
 
-      {:ok, source: tmp_path() |> Document.write!(pages) |> open!()}
+      {:ok, source: tmp_path() |> Document.write!(pages)}
     end
 
     test "writes the pages it was given", %{source: source, output: output} do
@@ -350,7 +349,7 @@ defmodule PDFiumTest do
     end
 
     test "keeps what is drawn on the page it took", %{output: output} do
-      source = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 100, 100}) |> open!()
+      source = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 100, 100})
 
       assert {:ok, :extracted} = Toolbox.extract_pages(source, [0], output)
 
@@ -366,10 +365,9 @@ defmodule PDFiumTest do
       assert {:error, :import_failed} = Toolbox.extract_pages(source, [9], output)
     end
 
-    test "reports a closed document", %{source: source, output: output} do
-      PDFium.close_document(source)
-
-      assert {:error, :document_closed} = Toolbox.extract_pages(source, [0], output)
+    test "reports a document it cannot open", %{output: output} do
+      assert {:error, :file} =
+               Toolbox.extract_pages("/nonexistent-directory/absent.pdf", [0], output)
     end
 
     test "reports an unwritable output path", %{source: source} do
@@ -379,7 +377,7 @@ defmodule PDFiumTest do
   end
 
   describe "merge/2" do
-    defp document!(pages), do: tmp_path() |> Document.write!(pages) |> open!()
+    defp document!(pages), do: tmp_path() |> Document.write!(pages)
 
     test "writes the documents as one, in order", %{output: output} do
       first = document!([[box: {0, 0, 100, 100}], [box: {0, 0, 200, 200}]])
@@ -401,8 +399,8 @@ defmodule PDFiumTest do
     end
 
     test "keeps what is drawn on each page", %{output: output} do
-      red = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 100, 100}) |> open!()
-      blue = tmp_path() |> Document.filled({0, 0, 1}, box: {0, 0, 100, 100}) |> open!()
+      red = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 100, 100})
+      blue = tmp_path() |> Document.filled({0, 0, 1}, box: {0, 0, 100, 100})
 
       assert {:ok, :merged} = Toolbox.merge([red, blue], output)
 
@@ -425,12 +423,10 @@ defmodule PDFiumTest do
       refute File.exists?(output)
     end
 
-    test "reports a closed document", %{output: output} do
+    test "reports a document it cannot open", %{output: output} do
       first = document!([[box: {0, 0, 100, 100}]])
-      second = document!([[box: {0, 0, 100, 100}]])
-      PDFium.close_document(second)
 
-      assert {:error, :document_closed} = Toolbox.merge([first, second], output)
+      assert {:error, :file} = Toolbox.merge([first, "/nonexistent-directory/absent.pdf"], output)
       refute File.exists?(output)
     end
 
@@ -533,9 +529,8 @@ defmodule PDFiumTest do
           [box: {0, 0, 400, 400}, content: "0 0 1 rg 0 0 400 400 re f"],
           [box: {0, 0, 400, 400}]
         ])
-        |> open!()
 
-      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]])
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{overlay, 0}], output)
       assert blue?(colour_at(output, 0.5, 0.5))
@@ -548,14 +543,14 @@ defmodule PDFiumTest do
 
       content = "0 0 1 rg #{left} #{bottom} #{width} #{height} re f"
 
-      tmp_path() |> Document.write!([[box: box, content: content]]) |> open!()
+      tmp_path() |> Document.write!([[box: box, content: content]])
     end
 
     defp blue?({red, green, blue}), do: blue > 200 and red < 100 and green < 100
 
     test "draws the overlay where it was drawn", %{output: output} do
       box = {0, 0, 400, 400}
-      document = tmp_path() |> Document.write!([[box: box]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: box]])
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{corner_overlay(box), 0}], output)
 
@@ -565,7 +560,7 @@ defmodule PDFiumTest do
 
     test "keeps the content the page already had", %{output: output} do
       box = {0, 0, 400, 400}
-      document = tmp_path() |> Document.filled({1, 0, 0}, box: box) |> open!()
+      document = tmp_path() |> Document.filled({1, 0, 0}, box: box)
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{corner_overlay(box), 0}], output)
 
@@ -576,7 +571,7 @@ defmodule PDFiumTest do
     test "draws over the page it was paired with and no other", %{output: output} do
       box = {0, 0, 400, 400}
       pages = [[box: box], [box: box], [box: box]]
-      document = tmp_path() |> Document.write!(pages) |> open!()
+      document = tmp_path() |> Document.write!(pages)
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{corner_overlay(box), 1}], output)
 
@@ -587,7 +582,7 @@ defmodule PDFiumTest do
 
     test "draws one overlay over as many pages as it is given", %{output: output} do
       box = {0, 0, 400, 400}
-      document = tmp_path() |> Document.write!([[box: box], [box: box]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: box], [box: box]])
       overlay = corner_overlay(box)
 
       assert {:ok, :stamped} =
@@ -599,10 +594,10 @@ defmodule PDFiumTest do
 
     test "stacks overlays on one page in the order given", %{output: output} do
       box = {0, 0, 400, 400}
-      document = tmp_path() |> Document.write!([[box: box]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: box]])
 
-      under = tmp_path() |> Document.filled({0, 1, 0}, box: box) |> open!()
-      over = tmp_path() |> Document.filled({1, 0, 0}, box: box) |> open!()
+      under = tmp_path() |> Document.filled({0, 1, 0}, box: box)
+      over = tmp_path() |> Document.filled({1, 0, 0}, box: box)
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{under, 0}, {over, 0}], output)
 
@@ -611,7 +606,7 @@ defmodule PDFiumTest do
 
     test "places against a box that does not start at the origin", %{output: output} do
       box = {-100, -100, 300, 300}
-      document = tmp_path() |> Document.write!([[box: box]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: box]])
       overlay = corner_overlay({0, 0, 400, 400})
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{overlay, 0}], output)
@@ -622,7 +617,7 @@ defmodule PDFiumTest do
 
     test "turns the overlay with the page it goes over", %{output: output} do
       box = {0, 0, 400, 600}
-      document = tmp_path() |> Document.write!([[box: box, rotation: 90]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: box, rotation: 90]])
 
       overlay = corner_overlay({0, 0, 600, 400})
 
@@ -634,8 +629,8 @@ defmodule PDFiumTest do
 
     test "scales an overlay of a different shape to fit, centred", %{output: output} do
       box = {0, 0, 400, 400}
-      document = tmp_path() |> Document.write!([[box: box]]) |> open!()
-      overlay = tmp_path() |> Document.filled({0, 0, 1}, box: {0, 0, 400, 800}) |> open!()
+      document = tmp_path() |> Document.write!([[box: box]])
+      overlay = tmp_path() |> Document.filled({0, 0, 1}, box: {0, 0, 400, 800})
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [{overlay, 0}], output)
 
@@ -645,29 +640,28 @@ defmodule PDFiumTest do
     end
 
     test "reports a page that is not there", %{output: output} do
-      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]]) |> open!()
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]])
 
       assert {:error, :page_load_failed} =
                Toolbox.stamp(document, [{corner_overlay({0, 0, 400, 400}), 9}], output)
     end
 
     test "reports an overlay with no pages", %{output: output} do
-      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]]) |> open!()
-      overlay = tmp_path() |> Document.write!([]) |> open!()
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]])
+      overlay = tmp_path() |> Document.write!([])
 
       assert {:error, :page_load_failed} = Toolbox.stamp(document, [{overlay, 0}], output)
     end
 
-    test "reports a closed document", %{output: output} do
-      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]]) |> open!()
-      overlay = corner_overlay({0, 0, 400, 400})
-      PDFium.close_document(overlay)
+    test "reports an overlay it cannot open", %{output: output} do
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]])
+      absent = "/nonexistent-directory/absent.pdf"
 
-      assert {:error, :document_closed} = Toolbox.stamp(document, [{overlay, 0}], output)
+      assert {:error, :file} = Toolbox.stamp(document, [{absent, 0}], output)
     end
 
     test "draws nothing when given nothing", %{output: output} do
-      document = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 400, 400}) |> open!()
+      document = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 400, 400})
 
       assert {:ok, :stamped} = Toolbox.stamp(document, [], output)
 
@@ -677,54 +671,33 @@ defmodule PDFiumTest do
 
   describe "flatten/2" do
     test "renders annotations into the page and writes the result", %{output: output} do
-      {:ok, document} = PDFium.load_document(@annotated)
-
-      assert {:ok, :flattened} = Toolbox.flatten(document, output)
+      assert {:ok, :flattened} = Toolbox.flatten(@annotated, output)
       assert File.exists?(output)
 
-      PDFium.close_document(document)
-
-      {:ok, flattened} = PDFium.load_document(output)
-      assert {:ok, 1} = PDFium.get_page_count(flattened)
-      PDFium.close_document(flattened)
+      assert {:ok, 1} = PDFium.get_page_count(open!(output))
     end
 
     test "leaves the output alone when there is nothing to flatten", %{output: output} do
-      {:ok, document} = PDFium.load_document(@plain)
-
-      assert {:ok, :nothing_to_do} = Toolbox.flatten(document, output)
+      assert {:ok, :nothing_to_do} = Toolbox.flatten(@plain, output)
       refute File.exists?(output)
-
-      PDFium.close_document(document)
     end
 
     test "is idempotent", %{output: output} do
-      {:ok, document} = PDFium.load_document(@annotated)
-      assert {:ok, :flattened} = Toolbox.flatten(document, output)
-      PDFium.close_document(document)
+      assert {:ok, :flattened} = Toolbox.flatten(@annotated, output)
 
-      {:ok, flattened} = PDFium.load_document(output)
       second = output <> ".2"
       on_exit(fn -> File.rm(second) end)
 
-      assert {:ok, :nothing_to_do} = Toolbox.flatten(flattened, second)
-      PDFium.close_document(flattened)
+      assert {:ok, :nothing_to_do} = Toolbox.flatten(output, second)
     end
 
-    test "reports a closed document", %{output: output} do
-      {:ok, document} = PDFium.load_document(@annotated)
-      PDFium.close_document(document)
-
-      assert {:error, :document_closed} = Toolbox.flatten(document, output)
+    test "reports a document it cannot open", %{output: output} do
+      assert {:error, :file} = Toolbox.flatten("/nonexistent-directory/absent.pdf", output)
     end
 
     test "reports an unwritable output path" do
-      {:ok, document} = PDFium.load_document(@annotated)
-
       assert {:error, :output_open_failed} =
-               Toolbox.flatten(document, "/nonexistent-directory/out.pdf")
-
-      PDFium.close_document(document)
+               Toolbox.flatten(@annotated, "/nonexistent-directory/out.pdf")
     end
   end
 end


### PR DESCRIPTION
Follows #119, and reads best after it.

`PDFium.Toolbox` took open documents and wrote to a path — half one thing, half the other. Every caller then wrote the same open/hand-over/close, and merging and stamping made it worse by needing several documents at once, which is what a plural `with_documents` was for.

Jobs now name their documents by path at both ends:

```elixir
PDFium.Toolbox.merge(["a.pdf", "b.pdf"], "merged.pdf")
PDFium.Toolbox.stamp("contract.pdf", [{"signature.pdf", 1}], "signed.pdf")
PDFium.Toolbox.flatten("annotated.pdf", "flat.pdf")
PDFium.Toolbox.extract_pages("long.pdf", [0, 2], "short.pdf")
```

Opening several documents is a job's own business, so it is a private helper here rather than public API. `PDFium` is still where you go to hold a document open across several pieces of work — `get_page_count`, `get_page_boxes`, rendering — and `PDFium.stamp/3` still takes references and a matrix for placing an overlay anywhere.

Two things worth knowing:

- `stamp/3` still opens a repeated overlay once, so stamping one overlay across many pages costs one open. `merge/2` deliberately does not: a document named twice is written twice.
- `extract_pages/3` opens the source each call. Splitting a document into chunks used to open it once for the whole loop, so that path now parses the source once per chunk. If that shows up, the answer is probably a job that takes the groups and writes them all, rather than handing references back to callers.