### PR TITLE
Build for every machine, not the one that compiled

### DIFF
--- a/custom/build-for-linux.sh
+++ b/custom/build-for-linux.sh
@@ -41,7 +41,6 @@ tar --extract --gunzip --directory=$pdfium_directory_name --file=$pdfium_archive
 
 # 4. Compile
 gcc \
-  -march=native \
   -Wall \
   -Wextra \
   -Werror \


### PR DESCRIPTION
file_service on staging is in CrashLoopBackOff with exit 132 (SIGILL) since it moved to 0.1.37. The cause is here.

`custom/build-for-linux.sh` compiles the NIF with `-march=native`, so the artifact targets whatever CPU the GitHub runner had. Comparing the published artifacts:

```
0.1.35  x86 feature used: x86, XMM, YMM
0.1.37  x86 feature used: x86, XMM, YMM, ZMM
```

ZMM is AVX-512. GKE `e2-standard-8` nodes do not have it, so the NIF takes an illegal instruction as soon as that path runs. Nothing in the source changed between those releases — only the machine that compiled them — which is why 0.1.35 works and 0.1.37 does not, and why this could return whenever runners are upgraded.

The flag is dropped rather than pinned to a baseline. What this compiles is glue that hands buffers between the VM and libpdfium; libpdfium is prebuilt and vectorised on its own terms, so there is nothing here worth tuning to a CPU.

Needs a release after merging, and the artifacts should be checked with `readelf -n` for ZMM before anything depends on them.