### PR TITLE
Build for every machine in the build CI actually runs

### DIFF
--- a/.dagger/lib/pdfium.ex
+++ b/.dagger/lib/pdfium.ex
@@ -156,7 +156,6 @@ defmodule Pdfium do
 
     compile = ~w(
       g++
-      -march=native
       -Wall
       -Wextra
       -Werror


### PR DESCRIPTION
0.1.38 was supposed to fix the SIGILL and did not. I dropped `-march=native` from `custom/build-for-linux.sh`, which nothing calls — the Linux artifacts are compiled by the dagger module, which carried the same flag.

The published 0.1.38 NIF is unchanged:

```
0.1.37  x86 feature used: x86, XMM, YMM, ZMM
0.1.38  x86 feature used: x86, XMM, YMM, ZMM
```

Caught by running `readelf -n` against the published artifact rather than trusting the diff.

This drops it from `.dagger/lib/pdfium.ex`, which is the build that actually produces what gets published. `grep -rn march` now returns nothing anywhere in the repo.

Needs another release, and the artifact wants checking again before file_service moves to it.