### PR TITLE
Draw the page of the overlay that belongs to the page

### DIFF
--- a/c_src/pdfium_nif.cpp
+++ b/c_src/pdfium_nif.cpp
@@ -576,7 +576,7 @@ Matrix display_to_page(const Box &box, int rotation) {
 // decides it.
 using Matrix6 = std::tuple<double, double, double, double, double, double>;
 
-using Placement = std::tuple<fine::ResourcePtr<PDFDoc>, int64_t, Matrix6>;
+using Placement = std::tuple<fine::ResourcePtr<PDFDoc>, int64_t, int64_t, Matrix6>;
 
 WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
                   std::vector<Placement> placements, std::string output_path) {
@@ -595,10 +595,10 @@ WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
     std::map<int, std::vector<size_t>> by_page;
 
     for (size_t index = 0; index < placements.size(); index++) {
-        by_page[static_cast<int>(std::get<1>(placements[index]))].push_back(index);
+        by_page[static_cast<int>(std::get<2>(placements[index]))].push_back(index);
     }
 
-    std::map<FPDF_DOCUMENT, FPDF_XOBJECT> templates;
+    std::map<std::pair<FPDF_DOCUMENT, int>, FPDF_XOBJECT> templates;
     std::optional<fine::Atom> failure;
 
     for (const auto &entry : by_page) {
@@ -613,26 +613,29 @@ WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
 
         for (size_t index : entry.second) {
             FPDF_DOCUMENT overlay = std::get<0>(placements[index])->document;
+            int overlay_page = static_cast<int>(std::get<1>(placements[index]));
+            auto key = std::make_pair(overlay, overlay_page);
 
-            if (templates.find(overlay) == templates.end()) {
-                FPDF_XOBJECT xobject = FPDF_NewXObjectFromPage(doc->document, overlay, 0);
+            if (templates.find(key) == templates.end()) {
+                FPDF_XOBJECT xobject =
+                    FPDF_NewXObjectFromPage(doc->document, overlay, overlay_page);
 
                 if (!xobject) {
                     failure = xobject_failed;
                     break;
                 }
 
-                templates[overlay] = xobject;
+                templates[key] = xobject;
             }
 
-            FPDF_PAGEOBJECT form = FPDF_NewFormObjectFromXObject(templates[overlay]);
+            FPDF_PAGEOBJECT form = FPDF_NewFormObjectFromXObject(templates[key]);
 
             if (!form) {
                 failure = form_object_failed;
                 break;
             }
 
-            const auto &[a, b, c, d, e, f] = std::get<2>(placements[index]);
+            const auto &[a, b, c, d, e, f] = std::get<3>(placements[index]);
 
             FPDFPageObj_Transform(form, a * inverse.a + b * inverse.c, a * inverse.b + b * inverse.d,
                                   c * inverse.a + d * inverse.c, c * inverse.b + d * inverse.d,

--- a/lib/pdfium.ex
+++ b/lib/pdfium.ex
@@ -204,20 +204,26 @@ defmodule PDFium do
   @doc """
   Draws overlays over the pages of `document` and writes the result.
 
-  Each placement is `{overlay, page_index, matrix}`, drawing the overlay's first
-  page over that page of the document, numbered from zero. Placements landing on
-  the same page stack in the order given.
+  Each placement is `{overlay, overlay_page, page_index, matrix}`, drawing that
+  page of the overlay over that page of the document, both numbered from zero.
+  Placements landing on the same page stack in the order given.
+
+  An overlay with a page per page of the document - a header and footer carrying
+  its own page numbers, say - is drawn by naming the page that belongs to each.
 
   An overlay arrives the way a reader shows it: turned the right way up, with
   its own box shifted onto the origin. The pages keep the content they already
   had.
   """
-  @spec stamp(reference(), [{reference(), non_neg_integer(), placement()}], Path.t()) ::
-          {:ok, :stamped} | {:error, atom()}
+  @spec stamp(
+          reference(),
+          [{reference(), non_neg_integer(), non_neg_integer(), placement()}],
+          Path.t()
+        ) :: {:ok, :stamped} | {:error, atom()}
   def stamp(document, placements, output_path) do
     placements =
-      Enum.map(placements, fn {overlay, page_index, {a, b, c, d, e, f}} ->
-        {overlay, page_index, {a / 1, b / 1, c / 1, d / 1, e / 1, f / 1}}
+      Enum.map(placements, fn {overlay, overlay_page, page_index, {a, b, c, d, e, f}} ->
+        {overlay, overlay_page, page_index, {a / 1, b / 1, c / 1, d / 1, e / 1, f / 1}}
       end)
 
     PDFium.NIF.stamp(document, placements, output_path)

--- a/lib/pdfium/toolbox.ex
+++ b/lib/pdfium/toolbox.ex
@@ -16,8 +16,11 @@ defmodule PDFium.Toolbox do
   Draws overlays over the pages of `document`, each scaled to fit and centred,
   and writes the result.
 
-  Each placement is `{overlay, page_index}`, with pages counted from zero.
-  Placements landing on the same page stack in the order given.
+  Each placement is `{overlay, page_index}`, with pages counted from zero, and
+  each overlay is drawn by its first page. Placements landing on the same page
+  stack in the order given.
+
+  `overlay/3` is for an overlay with a page per page of the document.
 
   Fitting and centring is what makes an overlay drawn at the size of the page it
   goes over land exactly where it was drawn. `PDFium.stamp/3` takes the matrix
@@ -30,7 +33,8 @@ defmodule PDFium.Toolbox do
 
     with_documents([path | overlay_paths], fn [document | overlays] ->
       by_path = Map.new(Enum.zip(overlay_paths, overlays))
-      named = Enum.map(placements, fn {path, page} -> {Map.fetch!(by_path, path), page} end)
+
+      named = Enum.map(placements, fn {path, page} -> {Map.fetch!(by_path, path), 0, page} end)
 
       with {:ok, [pages | overlay_pages]} <- PDFium.get_page_sizes([document | overlays]),
            sizes = overlays |> Enum.zip(overlay_pages) |> Map.new(),
@@ -40,31 +44,31 @@ defmodule PDFium.Toolbox do
     end)
   end
 
-  @spec fit_each([{reference(), non_neg_integer()}], [PDFium.page_size()], map()) ::
-          {:ok, [{reference(), non_neg_integer(), PDFium.placement()}]} | {:error, atom()}
+  @spec fit_each(
+          [{reference(), non_neg_integer(), non_neg_integer()}],
+          [PDFium.page_size()],
+          map()
+        ) ::
+          {:ok, [{reference(), non_neg_integer(), non_neg_integer(), PDFium.placement()}]}
+          | {:error, atom()}
   defp fit_each(placements, pages, sizes) do
-    Enum.reduce_while(placements, {:ok, []}, fn {overlay, page_index}, {:ok, placed} ->
-      with {:ok, overlay_size} <- first_page(Map.fetch!(sizes, overlay)),
+    Enum.reduce_while(placements, {:ok, []}, fn {overlay, overlay_page, page_index},
+                                                {:ok, placed} ->
+      with {:ok, overlay_size} <- page_at(Map.fetch!(sizes, overlay), overlay_page),
            {:ok, page} <- page_at(pages, page_index) do
-        {:cont, {:ok, placed ++ [{overlay, page_index, fit(overlay_size, page)}]}}
+        {:cont, {:ok, placed ++ [{overlay, overlay_page, page_index, fit(overlay_size, page)}]}}
       else
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
   end
 
-  @spec first_page([PDFium.page_size()]) :: {:ok, PDFium.page_size()} | {:error, atom()}
-  defp first_page([%{width: width, height: height} = size | _]) when width > 0 and height > 0,
-    do: {:ok, size}
-
-  defp first_page([_ | _]), do: {:error, :empty_overlay}
-  defp first_page([]), do: {:error, :page_load_failed}
-
   @spec page_at([PDFium.page_size()], non_neg_integer()) ::
           {:ok, PDFium.page_size()} | {:error, atom()}
   defp page_at(pages, index) do
     case Enum.at(pages, index) do
       nil -> {:error, :page_load_failed}
+      %{width: width, height: height} when width <= 0 or height <= 0 -> {:error, :empty_overlay}
       page -> {:ok, page}
     end
   end
@@ -74,6 +78,45 @@ defmodule PDFium.Toolbox do
     scale = min(page_width / width, page_height / height)
 
     {scale, 0.0, 0.0, scale, (page_width - width * scale) / 2, (page_height - height * scale) / 2}
+  end
+
+  @doc """
+  Draws each page of `overlay` over the page of `document` in the same place.
+
+  This is what a header and footer is: one page per page of the document, each
+  carrying that page's own number, and a header only where one belongs. Naming
+  the pairing is what the caller would otherwise have to spell out for every
+  page, and get right.
+
+  The two must have the same number of pages, which is refused rather than
+  guessed at - a mismatch means the overlay was rendered for a different
+  document.
+  """
+  @spec overlay(Path.t(), Path.t(), Path.t()) :: {:ok, :stamped} | {:error, atom()}
+  def overlay(path, overlay_path, output_path) do
+    with_documents([path, overlay_path], fn [document, overlay] ->
+      with {:ok, [pages, overlay_pages]} <- PDFium.get_page_sizes([document, overlay]),
+           true <- length(pages) == length(overlay_pages) || {:error, :page_count_mismatch},
+           {:ok, placed} <- fit_pairwise(overlay, pages, overlay_pages) do
+        PDFium.stamp(document, placed, output_path)
+      end
+    end)
+  end
+
+  @spec fit_pairwise(reference(), [PDFium.page_size()], [PDFium.page_size()]) ::
+          {:ok, [{reference(), non_neg_integer(), non_neg_integer(), PDFium.placement()}]}
+          | {:error, atom()}
+  defp fit_pairwise(overlay, pages, overlay_pages) do
+    pages
+    |> Enum.zip(overlay_pages)
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {{page, overlay_page}, index}, {:ok, placed} ->
+      if page.width > 0 and page.height > 0 and overlay_page.width > 0 and overlay_page.height > 0 do
+        {:cont, {:ok, placed ++ [{overlay, index, index, fit(overlay_page, page)}]}}
+      else
+        {:halt, {:error, :page_load_failed}}
+      end
+    end)
   end
 
   @doc """

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -487,7 +487,7 @@ defmodule PDFiumTest do
 
       placement = {1.0, 0.0, 0.0, 1.0, 200.0, 200.0}
 
-      assert {:ok, :stamped} = PDFium.stamp(document, [{overlay, 0, placement}], output)
+      assert {:ok, :stamped} = PDFium.stamp(document, [{overlay, 0, 0, placement}], output)
 
       assert blue?(colour_at(output, 0.625, 0.625)), "moved into the top right quarter"
       refute blue?(colour_at(output, 0.125, 0.125)), "not left in the bottom left"
@@ -498,7 +498,7 @@ defmodule PDFiumTest do
       document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]]) |> open!()
 
       assert {:ok, :stamped} =
-               PDFium.stamp(document, [{overlay, 0, {0.5, 0.0, 0.0, 0.5, 0.0, 0.0}}], output)
+               PDFium.stamp(document, [{overlay, 0, 0, {0.5, 0.0, 0.0, 0.5, 0.0, 0.0}}], output)
 
       assert blue?(colour_at(output, 0.25, 0.25)), "the quarter it was scaled into"
       refute blue?(colour_at(output, 0.75, 0.75)), "and nothing beyond it"
@@ -513,7 +513,7 @@ defmodule PDFiumTest do
         tmp_path() |> Document.write!([[box: {0, 0, 400, 600}, rotation: 90]]) |> open!()
 
       assert {:ok, :stamped} =
-               PDFium.stamp(document, [{overlay, 0, {1.0, 0.0, 0.0, 1.0, 0.0, 0.0}}], output)
+               PDFium.stamp(document, [{overlay, 0, 0, {1.0, 0.0, 0.0, 1.0, 0.0, 0.0}}], output)
 
       assert blue?(colour_at(output, 0.1, 0.1)), "the corner a reader calls bottom left"
     end
@@ -658,6 +658,32 @@ defmodule PDFiumTest do
       absent = "/nonexistent-directory/absent.pdf"
 
       assert {:error, :file} = Toolbox.stamp(document, [{absent, 0}], output)
+    end
+
+    test "draws each page of the overlay over the page in the same place" do
+      # A header and footer is drawn as one overlay page per page of the
+      # document, each carrying that page's own number.
+      overlay =
+        tmp_path()
+        |> Document.write!([
+          [box: {0, 0, 400, 400}, content: "1 0 0 rg 0 0 400 400 re f"],
+          [box: {0, 0, 400, 400}, content: "0 0 1 rg 0 0 400 400 re f"]
+        ])
+
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}], [box: {0, 0, 400, 400}]])
+      output = tmp_path()
+
+      assert {:ok, :stamped} = Toolbox.overlay(document, overlay, output)
+
+      assert colour_at(output, 0.5, 0.5, 0) == {255, 0, 0}, "page one takes overlay page one"
+      assert colour_at(output, 0.5, 0.5, 1) == {0, 0, 255}, "page two takes overlay page two"
+    end
+
+    test "refuses an overlay rendered for a document of another length" do
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}], [box: {0, 0, 400, 400}]])
+      overlay = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}]])
+
+      assert {:error, :page_count_mismatch} = Toolbox.overlay(document, overlay, tmp_path())
     end
 
     test "draws nothing when given nothing", %{output: output} do


### PR DESCRIPTION
Stamping always drew the overlay's **first** page, whatever page of the document it was going onto — `FPDF_NewXObjectFromPage(doc, overlay, 0)` — and cached the form object per overlay *document*, so every placement reused it.

That is wrong for the main thing overlays are used for. A header and footer is rendered as one overlay page per page of the contract, each carrying its own page number, and a header only on audit-trail pages. Drawing the first of them over every page numbers every page as page one and never draws the header at all.

Seen against file_service on a two page contract, before and after its migration to this library:

```
pdfcpu      page 2 footer: "Page: 2/2"
this        page 2 footer: "Page: 1/2"
```

## The shape

`PDFium.stamp/3` names the overlay page, because it is the building block and a caller there is placing something exactly:

```elixir
PDFium.stamp(document, [{overlay, overlay_page, page, matrix}], out)
```

The toolbox does not ask, because in both real cases the answer is not information:

```elixir
Toolbox.stamp(document, [{overlay, page}], out)   # an overlay drawn by its only page
Toolbox.overlay(document, band, out)              # a page per page, paired
```

An overlay drawn onto one named page is drawn by its only page, so every caller would have written `0`. An overlay with a page per page of the document is `overlay/3`, so every caller would have written the page twice. `overlay/3` refuses a page count that does not match rather than guessing — a mismatch means the overlay was rendered for a different document.

The toolbox also measures the page it is about to draw rather than the overlay's first, which is what it should have been fitting all along: with a many-paged overlay whose pages differ in size, every page was fitted to page one's dimensions. `first_page/1` goes with it, since `page_at/2` answers both questions.

## Tests

A two page overlay, red then blue, over a two page document, asserting each page takes its own colour — and a mismatched length is refused.

The old behaviour had a test asserting it, written during file_service's migration, whose comment said plainly *"only the first of them is ever drawn over anything here"*. It documented the behaviour rather than checking anyone wanted it.

Breaking change for `PDFium.stamp/3` callers. Needs a release; file_service then swaps its header and footer stamping for `overlay/3`.