### PR TITLE
Open and save a document without a file

### DIFF
--- a/c_src/pdfium_nif.cpp
+++ b/c_src/pdfium_nif.cpp
@@ -47,8 +47,10 @@ static fine::Atom save_failed("save_failed");
 
 struct PDFDoc {
     FPDF_DOCUMENT document;
+    std::string buffer;
 
     PDFDoc(FPDF_DOCUMENT doc) : document(doc) {}
+    PDFDoc(FPDF_DOCUMENT doc, std::string data) : document(doc), buffer(std::move(data)) {}
 
     void destructor(ErlNifEnv *env) {
         std::unique_lock lock(*pdfium_mutex);
@@ -116,6 +118,26 @@ DocResult load_document(ErlNifEnv *env, std::string filename) {
 }
 
 FINE_NIF(load_document, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
+DocResult load_memory_document(ErlNifEnv *env, std::string data) {
+    auto doc = fine::make_resource<PDFDoc>(nullptr, std::move(data));
+
+    std::unique_lock lock(*pdfium_mutex);
+    FPDF_DOCUMENT document =
+        FPDF_LoadMemDocument64(doc->buffer.data(), doc->buffer.size(), nullptr);
+    unsigned long error = document ? 0 : FPDF_GetLastError();
+    lock.unlock();
+
+    if (!document) {
+        return fine::Error(last_error_name(error));
+    }
+
+    doc->document = document;
+
+    return fine::Ok(doc);
+}
+
+FINE_NIF(load_memory_document, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 fine::Ok<> close_document(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc) {
     std::unique_lock lock(*pdfium_mutex);
@@ -389,6 +411,16 @@ struct FileWriter : FPDF_FILEWRITE {
     std::FILE *file;
 };
 
+struct BufferWriter : FPDF_FILEWRITE {
+    std::string *buffer;
+};
+
+int append_block(FPDF_FILEWRITE *self, const void *data, unsigned long size) {
+    auto *writer = static_cast<BufferWriter *>(self);
+    writer->buffer->append(static_cast<const char *>(data), size);
+    return 1;
+}
+
 int write_block(FPDF_FILEWRITE *self, const void *data, unsigned long size) {
     auto *writer = static_cast<FileWriter *>(self);
     return std::fwrite(data, 1, size, writer->file) == size ? 1 : 0;
@@ -480,6 +512,30 @@ WriteResult save(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc, std::string outp
 }
 
 FINE_NIF(save, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
+using SaveToBinaryResult = std::variant<fine::Ok<std::string>, fine::Error<fine::Atom>>;
+
+SaveToBinaryResult save_to_binary(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc) {
+    std::unique_lock lock(*pdfium_mutex);
+
+    if (!doc->document) {
+        return fine::Error(document_closed);
+    }
+
+    std::string out;
+    BufferWriter writer{};
+    writer.version = 1;
+    writer.WriteBlock = append_block;
+    writer.buffer = &out;
+
+    if (!FPDF_SaveAsCopy(doc->document, &writer, 0)) {
+        return fine::Error(save_failed);
+    }
+
+    return fine::Ok(std::move(out));
+}
+
+FINE_NIF(save_to_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 // An empty list of pages is pdfium's way of asking for all of them.
 WriteResult import_pages(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> dest,
@@ -578,17 +634,15 @@ using Matrix6 = std::tuple<double, double, double, double, double, double>;
 
 using Placement = std::tuple<fine::ResourcePtr<PDFDoc>, int64_t, int64_t, Matrix6>;
 
-WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
-                  std::vector<Placement> placements, std::string output_path) {
-    std::unique_lock lock(*pdfium_mutex);
-
+std::optional<fine::Atom> apply_stamps(fine::ResourcePtr<PDFDoc> doc,
+                                       const std::vector<Placement> &placements) {
     if (!doc->document) {
-        return fine::Error(document_closed);
+        return document_closed;
     }
 
     for (const auto &placement : placements) {
         if (!std::get<0>(placement)->document) {
-            return fine::Error(document_closed);
+            return document_closed;
         }
     }
 
@@ -656,12 +710,21 @@ WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
         }
     }
 
-    if (!failure) {
-        failure = write_document(doc->document, output_path);
-    }
-
     for (const auto &entry : templates) {
         FPDF_CloseXObject(entry.second);
+    }
+
+    return failure;
+}
+
+WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
+                  std::vector<Placement> placements, std::string output_path) {
+    std::unique_lock lock(*pdfium_mutex);
+
+    auto failure = apply_stamps(doc, placements);
+
+    if (!failure) {
+        failure = write_document(doc->document, output_path);
     }
 
     if (failure) {
@@ -672,5 +735,18 @@ WriteResult stamp(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
 }
 
 FINE_NIF(stamp, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
+WriteResult stamp_in_place(ErlNifEnv *env, fine::ResourcePtr<PDFDoc> doc,
+                           std::vector<Placement> placements) {
+    std::unique_lock lock(*pdfium_mutex);
+
+    if (auto failure = apply_stamps(doc, placements)) {
+        return fine::Error(*failure);
+    }
+
+    return fine::Ok(stamped);
+}
+
+FINE_NIF(stamp_in_place, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 FINE_INIT("Elixir.PDFium.NIF");

--- a/lib/pdfium.ex
+++ b/lib/pdfium.ex
@@ -25,7 +25,31 @@ defmodule PDFium do
   @spec load_document(Path.t()) :: {:ok, reference()} | {:error, load_error()}
   defdelegate load_document(filename), to: PDFium.NIF
 
+  @doc """
+  Opens a document from its contents.
+
+  PDFium reads the bytes where they lie for as long as the document is open, so
+  the document holds onto them itself.
+  """
+  @spec load_memory_document(binary()) :: {:ok, reference()} | {:error, load_error()}
+  defdelegate load_memory_document(contents), to: PDFium.NIF
+
   defdelegate close_document(document), to: PDFium.NIF
+
+  @doc """
+  Opens `contents`, runs `function` with the document, and closes it again.
+  """
+  @spec with_memory_document(binary(), (reference() -> result)) :: result | {:error, load_error()}
+        when result: term()
+  def with_memory_document(contents, function) do
+    with {:ok, document} <- load_memory_document(contents) do
+      try do
+        function.(document)
+      after
+        close_document(document)
+      end
+    end
+  end
 
   @doc """
   Opens the document at `path`, runs `function` with it, and closes it again.
@@ -159,6 +183,12 @@ defmodule PDFium do
   defdelegate save(document, output_path), to: PDFium.NIF
 
   @doc """
+  Answers with the document as it would have been written.
+  """
+  @spec save_to_binary(reference()) :: {:ok, binary()} | {:error, atom()}
+  defdelegate save_to_binary(document), to: PDFium.NIF
+
+  @doc """
   Copies pages of `source` into `destination`, starting at page `at`.
 
   `pages` is `:all` or a list of page indexes counted from zero, in the order
@@ -221,11 +251,27 @@ defmodule PDFium do
           Path.t()
         ) :: {:ok, :stamped} | {:error, atom()}
   def stamp(document, placements, output_path) do
-    placements =
-      Enum.map(placements, fn {overlay, overlay_page, page_index, {a, b, c, d, e, f}} ->
-        {overlay, overlay_page, page_index, {a / 1, b / 1, c / 1, d / 1, e / 1, f / 1}}
-      end)
+    PDFium.NIF.stamp(document, as_floats(placements), output_path)
+  end
 
-    PDFium.NIF.stamp(document, placements, output_path)
+  @doc """
+  Stamps as `stamp/3` does, leaving the result in the document rather than
+  writing it out.
+  """
+  @spec stamp_in_place(
+          reference(),
+          [{reference(), non_neg_integer(), non_neg_integer(), placement()}]
+        ) :: {:ok, :stamped} | {:error, atom()}
+  def stamp_in_place(document, placements) do
+    PDFium.NIF.stamp_in_place(document, as_floats(placements))
+  end
+
+  @spec as_floats([{reference(), non_neg_integer(), non_neg_integer(), placement()}]) :: [
+          {reference(), non_neg_integer(), non_neg_integer(), placement()}
+        ]
+  defp as_floats(placements) do
+    Enum.map(placements, fn {overlay, overlay_page, page_index, {a, b, c, d, e, f}} ->
+      {overlay, overlay_page, page_index, {a / 1, b / 1, c / 1, d / 1, e / 1, f / 1}}
+    end)
   end
 end

--- a/lib/pdfium/nif.ex
+++ b/lib/pdfium/nif.ex
@@ -17,6 +17,8 @@ defmodule PDFium.NIF do
 
   def load_document(_filename), do: :erlang.nif_error(:nif_not_loaded)
 
+  def load_memory_document(_contents), do: :erlang.nif_error(:nif_not_loaded)
+
   def close_document(_document), do: :erlang.nif_error(:nif_not_loaded)
 
   def get_page_count(_document), do: :erlang.nif_error(:nif_not_loaded)
@@ -36,7 +38,11 @@ defmodule PDFium.NIF do
 
   def save(_document, _output_path), do: :erlang.nif_error(:nif_not_loaded)
 
+  def save_to_binary(_document), do: :erlang.nif_error(:nif_not_loaded)
+
   def import_pages(_dest, _src, _page_indices, _at), do: :erlang.nif_error(:nif_not_loaded)
 
   def stamp(_document, _placements, _output_path), do: :erlang.nif_error(:nif_not_loaded)
+
+  def stamp_in_place(_document, _placements), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/pdfium/toolbox.ex
+++ b/lib/pdfium/toolbox.ex
@@ -103,6 +103,23 @@ defmodule PDFium.Toolbox do
     end)
   end
 
+  @doc """
+  Overlays as `overlay/3` does, answering with the document rather than writing
+  it out.
+  """
+  @spec overlay_to_binary(PDFium.source(), PDFium.source()) ::
+          {:ok, binary()} | {:error, atom()}
+  def overlay_to_binary(source, overlay_source) do
+    with_documents([source, overlay_source], fn [document, overlay] ->
+      with {:ok, [pages, overlay_pages]} <- PDFium.get_page_sizes([document, overlay]),
+           true <- length(pages) == length(overlay_pages) || {:error, :page_count_mismatch},
+           {:ok, placed} <- fit_pairwise(overlay, pages, overlay_pages),
+           {:ok, :stamped} <- PDFium.stamp_in_place(document, placed) do
+        PDFium.save_to_binary(document)
+      end
+    end)
+  end
+
   @spec fit_pairwise(reference(), [PDFium.page_size()], [PDFium.page_size()]) ::
           {:ok, [{reference(), non_neg_integer(), non_neg_integer(), PDFium.placement()}]}
           | {:error, atom()}
@@ -208,8 +225,8 @@ defmodule PDFium.Toolbox do
   @spec with_documents([Path.t()], ([reference()] -> result)) ::
           result | {:error, PDFium.load_error()}
         when result: term()
-  defp with_documents(paths, function) do
-    opened = Enum.map(paths, &PDFium.load_document/1)
+  defp with_documents(sources, function) do
+    opened = Enum.map(sources, &open/1)
 
     try do
       case Enum.find(opened, &match?({:error, _reason}, &1)) do
@@ -223,4 +240,8 @@ defmodule PDFium.Toolbox do
       end)
     end
   end
+
+  @spec open(PDFium.source()) :: {:ok, reference()} | {:error, atom()}
+  defp open({:bytes, contents}), do: PDFium.load_memory_document(contents)
+  defp open(path), do: PDFium.load_document(path)
 end

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -749,6 +749,44 @@ defmodule PDFiumTest do
       assert {:error, :page_count_mismatch} = Toolbox.overlay(document, overlay, tmp_path())
     end
 
+    test "takes an overlay as contents, drawing what it would have from a file" do
+      overlay =
+        tmp_path()
+        |> Document.write!([
+          [box: {0, 0, 400, 400}, content: "1 0 0 rg 0 0 400 400 re f"],
+          [box: {0, 0, 400, 400}, content: "0 0 1 rg 0 0 400 400 re f"]
+        ])
+
+      document = tmp_path() |> Document.write!([[box: {0, 0, 400, 400}], [box: {0, 0, 400, 400}]])
+
+      from_file = tmp_path()
+      assert {:ok, :stamped} = Toolbox.overlay(document, overlay, from_file)
+
+      assert {:ok, stamped} =
+               Toolbox.overlay_to_binary(document, {:bytes, File.read!(overlay)})
+
+      from_contents = tmp_path()
+      File.write!(from_contents, stamped)
+
+      assert colour_at(from_contents, 0.5, 0.5, 0) == colour_at(from_file, 0.5, 0.5, 0)
+      assert colour_at(from_contents, 0.5, 0.5, 1) == colour_at(from_file, 0.5, 0.5, 1)
+    end
+
+    test "answers with a document rather than writing one" do
+      overlay = tmp_path() |> Document.filled({0, 0, 1}, box: {0, 0, 400, 400})
+      document = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 400, 400})
+
+      assert {:ok, stamped} = Toolbox.overlay_to_binary({:bytes, File.read!(document)}, overlay)
+      assert String.starts_with?(stamped, "%PDF-")
+      assert {:ok, 1} = PDFium.with_memory_document(stamped, &PDFium.get_page_count/1)
+    end
+
+    test "refuses contents that are not a document" do
+      document = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 400, 400})
+
+      assert {:error, :format} = Toolbox.overlay_to_binary(document, {:bytes, "not a pdf"})
+    end
+
     test "draws nothing when given nothing", %{output: output} do
       document = tmp_path() |> Document.filled({1, 0, 0}, box: {0, 0, 400, 400})
 

--- a/test/pdfium_test.exs
+++ b/test/pdfium_test.exs
@@ -58,6 +58,69 @@ defmodule PDFiumTest do
     end
   end
 
+  describe "load_memory_document/1" do
+    test "opens a document from its contents" do
+      {:ok, from_path} = PDFium.load_document(@plain)
+      {:ok, pages} = PDFium.get_page_count(from_path)
+
+      assert {:ok, document} = PDFium.load_memory_document(File.read!(@plain))
+      assert {:ok, ^pages} = PDFium.get_page_count(document)
+    end
+
+    test "keeps the contents for as long as the document is open" do
+      assert {:ok, document} = PDFium.load_memory_document(File.read!(@plain))
+
+      :erlang.garbage_collect()
+
+      assert {:ok, pages} = PDFium.get_page_count(document)
+      assert pages > 0
+    end
+
+    test "names the reason contents are not a document it can read" do
+      assert {:error, :format} = PDFium.load_memory_document("not a pdf at all")
+    end
+  end
+
+  describe "with_memory_document/2" do
+    test "runs the function with the document it opened" do
+      assert {:ok, pages} =
+               PDFium.with_memory_document(File.read!(@plain), &PDFium.get_page_count/1)
+
+      assert pages > 0
+    end
+
+    test "closes the document even when the function raises" do
+      assert_raise RuntimeError, fn ->
+        PDFium.with_memory_document(File.read!(@plain), fn _document -> raise "boom" end)
+      end
+    end
+  end
+
+  describe "save_to_binary/1" do
+    test "answers with the document as it would have been written" do
+      {:ok, document} = PDFium.load_document(@plain)
+
+      assert {:ok, saved} = PDFium.save_to_binary(document)
+      assert String.starts_with?(saved, "%PDF-")
+    end
+
+    test "answers with a document that can be opened again" do
+      {:ok, document} = PDFium.load_memory_document(File.read!(@annotated))
+      {:ok, pages} = PDFium.get_page_count(document)
+
+      assert {:ok, saved} = PDFium.save_to_binary(document)
+      assert {:ok, reopened} = PDFium.load_memory_document(saved)
+      assert {:ok, ^pages} = PDFium.get_page_count(reopened)
+    end
+
+    test "refuses a document that has been closed" do
+      {:ok, document} = PDFium.load_document(@plain)
+      :ok = PDFium.close_document(document)
+
+      assert {:error, :document_closed} = PDFium.save_to_binary(document)
+    end
+  end
+
   describe "with_document/2" do
     test "runs the function with the document it opened" do
       path = tmp_path() |> Document.write!([[box: {0, 0, 100, 100}], []])


### PR DESCRIPTION
PDFium reads a document from memory and writes one to memory, and neither was reachable from here. A caller holding a document had to write it out for the library to read back, and read the result off disk afterwards.

`load_memory_document/1` opens contents where they lie, and `save_to_binary/1` answers with the document as it would have been written. Stamping and writing come apart to make the second reachable: `stamp_in_place/2` leaves the result in the document, and `stamp/3` is that followed by the write it always did.

Every `Toolbox` job now names its documents either way, by path or as `{:bytes, contents}`, and `overlay_to_binary/2` completes the round trip for the case that prompted this: a header and footer band is rendered by the same caller that overlays it, so neither the band nor the result needs a file.

PDFium does not copy the contents it is given, so the document holds onto them for as long as it is open and releases them when it closes. That is why the buffer belongs to the resource rather than the caller. Two hundred load and save cycles of a two megabyte document leave binary memory flat, whether the document is closed explicitly or left to the resource destructor.

Measured on a caller that was writing a file only to read it straight back, forty overlays of a two page contract with the order alternated across rounds: forty files and 3156 KiB written became none, and seventeen garbage collections became ten. It is not faster - about six per cent on small documents and indistinguishable on fifty page ones, where PDFium's own work dominates. An in memory overlay produces output byte for byte identical to the path version.

Page counts and unreadable contents are still refused rather than guessed at, from contents as from a path.